### PR TITLE
SQL Datenbank anstelle von PostgreSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
-        <!-- PostgreSQL Treiber -->
+        <!-- MariaDB Treiber -->
         <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>42.7.2</version>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
         </dependency>
 
         <!-- Lombok (vereinfachte Code-Schreibweise) -->

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,5 @@
 spring.application.name=salesAPI
-spring.datasource.url=jdbc:postgresql://localhost:5432/product_import_db
-spring.datasource.username=postgres
-spring.datasource.password=admin
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.hikari.minimum-idle=5
-spring.datasource.hikari.maximum-pool-size=10
-
-# JPA-Einstellungen
-spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.open-in-view=false
+spring.datasource.url=jdbc:mariadb://localhost:3306/DatenbanknameHier
+spring.datasource.username=root
+spring.datasource.password=
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver


### PR DESCRIPTION
Da wir nun MariaDB anstelle von PostgreSQL verwenden, habe ich das mal geändert, vielleicht ist das dann für alle hilfreich.

Der Datenbankname muss individuell angepasst werden.